### PR TITLE
A few changes for compilation with Microchip's XC16 compiler

### DIFF
--- a/src/actuator.c
+++ b/src/actuator.c
@@ -7,8 +7,12 @@
 #include "control_chain.h"
 #include "actuator.h"
 #include "update.h"
+#ifdef XC16
+extern float roundf(float);
+extern float fabsf(float);
+#else
 #include <math.h>
-
+#endif
 
 /*
 ****************************************************************************************************

--- a/src/actuator.c
+++ b/src/actuator.c
@@ -217,8 +217,15 @@ cc_actuator_t *cc_actuator_new(cc_actuator_config_t *config)
 
 void cc_actuator_map(cc_assignment_t *assignment)
 {
+#ifdef XC16
+    uint8_t i;
+#endif
     // link assignment to actuator
+#ifdef XC16
+    for (i = 0; i < g_actuators_count; i++)
+#else
     for (uint8_t i = 0; i < g_actuators_count; i++)
+#endif
     {
         cc_actuator_t *actuator = &g_actuators[i];
         if (actuator->id == assignment->actuator_id)
@@ -232,7 +239,11 @@ void cc_actuator_map(cc_assignment_t *assignment)
     // initialize option list index
     if (assignment->mode & CC_MODE_OPTIONS)
     {
+#ifdef XC16
         for (int i = 0; i < assignment->list_count; i++)
+#else
+        for (int i = 0; i < assignment->list_count; i++)
+#endif
         {
             if (assignment->value == assignment->list_items[i]->value)
             {
@@ -246,7 +257,14 @@ void cc_actuator_map(cc_assignment_t *assignment)
 
 void cc_actuator_unmap(cc_assignment_t *assignment)
 {
+#ifdef XC16
+    uint8_t i;
+#endif
+#ifdef XC16
+    for (i = 0; i < g_actuators_count; i++)
+#else
     for (uint8_t i = 0; i < g_actuators_count; i++)
+#endif
     {
         cc_actuator_t *actuator = &g_actuators[i];
         if (actuator->id == assignment->actuator_id)
@@ -259,7 +277,14 @@ void cc_actuator_unmap(cc_assignment_t *assignment)
 
 void cc_actuators_process(void (*events_cb)(void *arg))
 {
+#ifdef XC16
+	uint8_t i;
+#endif
+#ifdef XC16
+    for (i = 0; i < g_actuators_count; i++)
+#else
     for (uint8_t i = 0; i < g_actuators_count; i++)
+#endif
     {
         cc_actuator_t *actuator = &g_actuators[i];
         cc_assignment_t *assignment = actuator->assignment;

--- a/src/assignment.c
+++ b/src/assignment.c
@@ -55,16 +55,26 @@ static cc_assignment_t g_assignments[MAX_ASSIGNMENTS];
 
 cc_assignment_t *cc_assignment_new(void)
 {
+#ifdef XC16
+    int i;
+#endif
     static int assignments_initialized;
     if (!assignments_initialized)
     {
+#ifdef XC16
+        for (i = 0; i < MAX_ASSIGNMENTS; i++)
+#else
         for (int i = 0; i < MAX_ASSIGNMENTS; i++)
+#endif
             g_assignments[i].id = -1;
 
         assignments_initialized = 1;
     }
-
+#ifdef XC16
+    for (i = 0; i < MAX_ASSIGNMENTS; i++)
+#else
     for (int i = 0; i < MAX_ASSIGNMENTS; i++)
+#endif
     {
         cc_assignment_t *assignment = &g_assignments[i];
 
@@ -80,7 +90,14 @@ cc_assignment_t *cc_assignment_new(void)
 
 int cc_assignment_delete(int assignment_id)
 {
+#ifdef XC16
+    int i;
+#endif
+#ifdef XC16
+    for (i = 0; i < MAX_ASSIGNMENTS; i++)
+#else
     for (int i = 0; i < MAX_ASSIGNMENTS; i++)
+#endif
     {
         cc_assignment_t *assignment = &g_assignments[i];
 

--- a/src/core.c
+++ b/src/core.c
@@ -74,6 +74,9 @@ static cc_handle_t g_cc_handle;
 
 static void send(cc_handle_t *handle, const cc_msg_t *msg)
 {
+#ifdef XC16
+    uint32_t j;
+#endif
     uint8_t *buffer = handle->msg_tx->header;
 
     // header
@@ -88,7 +91,11 @@ static void send(cc_handle_t *handle, const cc_msg_t *msg)
     {
         if (msg != handle->msg_tx)
         {
+#ifdef XC16
+            for (j = 0; j < msg->data_size; j++)
+#else
             for (uint32_t j = 0; j < msg->data_size; j++)
+#endif
                 buffer[i++] = msg->data[j];
         }
         else

--- a/src/example_config.h
+++ b/src/example_config.h
@@ -1,0 +1,56 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+// define firmware version
+#define CC_FIRMWARE_MAJOR   0
+#define CC_FIRMWARE_MINOR   5
+#define CC_FIRMWARE_MICRO   1
+
+////////// Arduino Uno
+#ifdef ARDUINO_AVR_UNO
+
+// maximum number of devices that can be created
+#define CC_MAX_DEVICES      1
+// maximum number of actuators that can be created per device
+#define CC_MAX_ACTUATORS    4
+// maximum number of assignments that can be created per actuator
+#define CC_MAX_ASSIGNMENTS  1
+
+// define the size of the queue used to store the updates before send them
+#define CC_UPDATES_FIFO_SIZE    10
+
+// disable string support
+#define CC_STRING_NOT_SUPPORTED
+
+////////// Arduino Due
+#elif defined (ARDUINO_SAM_DUE)
+
+// maximum number of devices that can be created
+#define CC_MAX_DEVICES      1
+// maximum number of actuators that can be created per device
+#define CC_MAX_ACTUATORS    8
+// maximum number of assignments that can be created per actuator
+#define CC_MAX_ASSIGNMENTS  1
+
+// define the size of the queue used to store the updates before send them
+#define CC_UPDATES_FIFO_SIZE    20
+
+////////// All other Arduinos
+#else
+
+// maximum number of devices that can be created
+#define CC_MAX_DEVICES      1
+// maximum number of actuators that can be created per device
+#define CC_MAX_ACTUATORS    2
+// maximum number of assignments that can be created per actuator
+#define CC_MAX_ASSIGNMENTS  1
+
+// define the size of the queue used to store the updates before send them
+#define CC_UPDATES_FIFO_SIZE    5
+
+// disable string support
+#define CC_STRING_NOT_SUPPORTED
+
+#endif
+
+#endif

--- a/src/msg.c
+++ b/src/msg.c
@@ -177,6 +177,9 @@ int cc_msg_parser(const cc_msg_t *msg, void *data_struct)
 
 int cc_msg_builder(int command, const void *data_struct, cc_msg_t *msg)
 {
+#ifdef XC16
+    unsigned int i;
+#endif
     uint8_t *pdata = msg->data;
     msg->command = command;
 
@@ -212,7 +215,11 @@ int cc_msg_builder(int command, const void *data_struct, cc_msg_t *msg)
         *pdata++ = device->actuators_count;
 
         // serialize actuators data
+#ifdef XC16
+        for (i = 0; i < device->actuators_count; i++)
+#else
         for (unsigned int i = 0; i < device->actuators_count; i++)
+#endif
         {
             cc_actuator_t *actuator = device->actuators[i];
 


### PR DESCRIPTION
I don't know if these changes would be acceptable or even if you accept pull requests.

I'm compiling this library of code with the XC16 compiler for a microchip PIC micro-controller. There are a number of external dependencies, (timer functions and two functions to process float values). I have to implement those dependencies or use implementations in Microchip's libraries. I tend to write my own, but that's my issue.

The timer functions used by the library are declared in 'timer.h', which is great it just means my project has to implement. The use of the Arduino header <math.h> in the top of 'actuator.c' is less straight forward. Perhaps I could have added another header file to this library 'cc_math.h' that declares the two external functions used? That would clean up the top of actuator.c.

The other changes are due to the code using C99 variable declarations in a 'for' statement. I could possibly have found the C99 compiler option to allow these declarations. Perhaps I could have used a 'C99' switch to #define alternative code. For the moment so that I can get the library compiling I've simply used the 'XC16' Switch. Perhaps I should be compiling for C99 but it seems a bit out dated at this point.

Let me know if you'd like changes to this PR or if you even accept changes.